### PR TITLE
re-enable renovate with 14-day cooldown

### DIFF
--- a/POCs/OP-gcp-microservices-demo-sandbox/.github/renovate.json5
+++ b/POCs/OP-gcp-microservices-demo-sandbox/.github/renovate.json5
@@ -21,4 +21,6 @@
       "kustomize/base/**"
     ]
   },
+
+  "minimumReleaseAge": "14 days"
 }


### PR DESCRIPTION
> [!NOTE]
> **Merge only if this is still needed and your repo is not managed by ADMS.**
> If your repository is already managed by ADMS, feel free to close or ignore this PR.

---

We are adding a mandatory 14-day cooldown (`minimumReleaseAge`) on dependencies to reduce the risk of zero-day vulnerabilities.

Please expect PRs that re-enable updaters and introduce the cooldown setting. If you notice any configurations that were not disabled on your repos, please ensure a cooldown is added.

If your repository is already managed by ADMS and no longer requires these configurations, feel free to close or ignore the PR.